### PR TITLE
Add VAAPI to HEVC 10bit bitrate reduction

### DIFF
--- a/bin/other-transcode
+++ b/bin/other-transcode
@@ -874,7 +874,7 @@ HERE
         end
       end
 
-      @ten_bit = (@hevc and @encoder =~ /(nvenc|qsv|x265)$/ ? true : false) if @ten_bit.nil?
+      @ten_bit = (@hevc and @encoder =~ /(nvenc|qsv|vaapi|x265)$/ ? true : false) if @ten_bit.nil?
       @target_2160p ||= (@hevc and @ten_bit) ? 12000 : 16000
       @target_1080p ||= (@hevc and @ten_bit) ? 6000  : 8000
       @target_720p  ||= (@hevc and @ten_bit) ? 3000  : 4000


### PR DESCRIPTION
When using VAAPI with HEVC the bitrate stays at 8000Kbps instead of being reduced to 6000Kbps like with the other encoders. It looks like this is because `vaapi` isn't being matched in the `@ten_bit` regex. 

I just added it to that list. 😄 

I'm assuming that is the correct thing to match, since the result of the `try_encoder` function is successful with:

`Trying "hevc_vaapi" video encoder...`