### PR TITLE
updating escape command to current MPV requirements

### DIFF
--- a/bin/other-transcode
+++ b/bin/other-transcode
@@ -1333,10 +1333,10 @@ HERE
         drawbox_string = "#{crop[:x]}:#{crop[:y]}:#{crop[:width]}:#{crop[:height]}"
         puts
         puts escape_command([
-          'mpv', '--no-audio', '--vf', "lavfi=[drawbox=#{drawbox_string}:invert:1]", path
+          'mpv', '--no-audio', '--vf="lavfi=[drawbox=#{drawbox_string}:invert:1]"', path
         ])
         puts escape_command([
-          'mpv', '--no-audio', '--vf', "crop=#{crop_string}", path
+          'mpv', '--no-audio', '--vf="crop=#{crop_string}"', path
         ])
         puts
         puts escape_command([


### PR DESCRIPTION
When running this command
`mpv --no-audio --vf lavfi=[drawbox=0:140:1920:800:invert:1] "D:\Movies\moviename.mkv"`

or this one

` mpv --no-audio --vf crop=1920:800:0:140 "D:\Movies\moviename.mkv"`

using the latest version of MPV

```
mpv 0.32.0-456-g4e94b2177a Copyright © 2000-2020 mpv/MPlayer/mplayer2 projects built on Sun May 10 23:34:45 +08 2020  
FFmpeg library versions:   
libavutil       56.43.100  
libavcodec      58.83.100  
libavformat     58.43.100  
libswscale      5.6.101  
libavfilter     7.80.100  
libswresample   3.6.100  
FFmpeg version: git-2020-05-10-5727b1f13
```

The following error is generated:

```
Make sure you're using e.g. '--vf=value' instead of '--vf value'.
Exiting... (Fatal error)
```

This pull requests slightly edits the escape command to PS to include the correct code snippet to copy and paste. 