### PR TITLE
Update handling of BT.470 BG color transfer

### DIFF
--- a/bin/other-transcode
+++ b/bin/other-transcode
@@ -1753,7 +1753,7 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
       end
 
       color_primaries = video['color_primaries']
-      color_trc       = video['color_transfer']
+      color_trc       = video['color_transfer'] == 'bt470bg' ? 'gamma28' : video['color_transfer']
       colorspace      = video['color_space']
       ten_bit = (@ten_bit ? (@eight_bit_vc1 ? (video['codec_name'] != 'vc1') : true) : false)
 


### PR DESCRIPTION
ffmpeg does not support a passing a bt470bg value for color_trc.  Based on https://ffmpeg.org/ffmpeg-codecs.html, the equivalent value is gamma28.  This update maps the bt470bg value to gamma28 when setting color_trc.

There may be other similar values that need to be mapped but this is the only one I've encountered in my own testing.

I encountered this issue when transcoding some older videos.