### PR TITLE
Add `--convert-dvb-subs` option.

### DIFF
--- a/bin/other-transcode
+++ b/bin/other-transcode
@@ -319,6 +319,9 @@ Subtitle options:
                     burn subtitle track by number into video
                       or enable automatic burning of forced subtitle
                       (only image-based subtitles are burned)
+    --convert-dvb-subs
+                   convert "DVB Subtitle" format subtitles to 
+                    "DVD Subtitle" format
 
 Other options:
 -h, --help [more|full]
@@ -407,6 +410,7 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
       @subtitle_selections = []
       @auto_add_subtitle = false
       @burn_subtitle_track = 0
+      @convert_dvb_subs = false
     end
 
     def run
@@ -997,6 +1001,11 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
 
         @encoder = nil if @encoder == 'copy'
       end
+
+      opts.on '--convert-dvb-subs' do
+        @convert_dvb_subs = true
+      end
+
     end
 
     def resolve_time(arg)
@@ -2270,7 +2279,7 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
 
         options += [
           '-map', "0:#{subtitle['index']}",
-          "-c:s:#{index}", ((@format == :mp4 and subtitle['codec_name'] == 'subrip') ? 'mov_text' : 'copy'),
+          "-c:s:#{index}", get_subtitle_codec(subtitle),
           "-disposition:s:#{index}", (force ? 'default+forced' : '0')
         ]
 
@@ -2280,6 +2289,16 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
       return ['-sn'] if options.empty?
 
       options
+    end
+
+    def get_subtitle_codec(subtitle)
+      out_codec = ((@format == :mp4 and subtitle['codec_name'] == 'subrip') ? 'mov_text' : 'copy')
+      
+      if subtitle['codec_name'] == 'dvb_subtitle' and @convert_dvb_subs
+        out_codec = 'dvdsub'
+      end
+      
+      return out_codec
     end
 
     def assemble_log(log_path, output)


### PR DESCRIPTION
Hi Don, sorry to intrude.

I've made a few changes to my installation of **other-transcode** to meet a few local needs and I thought this one might be of wider interest.

If the `--add-subtitle` option is invoked, by default **other-transcode** copies the selected subtitle track(s) in their original format. If the original format is _DVB Subtitle_ (dvb_subtitle) then this causes problems with both MP4 and MKV output formats. In the case of MP4 output the transcode fails immediately, in the case of MKV some players don't support the DVB Subtitle format. This option, `--convert-dvb-subs ` configures **ffmpeg** to convert _DVB_ subtitles to _DVD_ subtitles. This prevents MP4 output failing and the _DVD_ subtitle format is supported by a wider variety of players.

Hope this is of interest,

Kind regards,

Alan.