### PR TITLE
Add `--output` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Or this on Linux and macOS:
 
     other-transcode /Rips/Movie.mkv
 
-On completion that command creates two files in the current working directory:
+On completion that command creates two files in the current working directory (unless you set a different path with `--output`):
 
     Movie.mkv
     Movie.mkv.log

--- a/bin/other-transcode
+++ b/bin/other-transcode
@@ -50,6 +50,10 @@ Input options:
     def usage3
       <<-HERE
 Output options:
+    --output FILENAME|DIRECTORY
+                    set output path and filename, or just path
+                      (default: input filename with output format extension
+                        in current working directory)
     --debug         increase diagnostic information
     --scan          print media information and exit
     --preview-crop  show commands to preview detected video crop and exit
@@ -333,6 +337,7 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
     def initialize
       @position = nil
       @duration = nil
+      @output = nil
       @debug = false
       @scan = false
       @detect = false
@@ -466,6 +471,21 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
 
       opts.on '--duration ARG' do |arg|
         @duration = resolve_time(arg)
+      end
+
+      opts.on '--output ARG' do |arg|
+        unless File.directory? arg
+          @format = case File.extname(arg)
+          when '.mkv'
+            :mkv # COMBAK: Already the default. Chop this block?
+          when '.mp4'
+            :mp4
+          else
+            fail UsageError, "unsupported filename extension: #{arg}"
+          end
+        end
+
+        @output = arg
       end
 
       opts.on '--debug' do
@@ -1161,11 +1181,28 @@ Requires `ffprobe`, `ffmpeg` and `mkvpropedit`.
       $CHILD_STATUS.exitstatus == 0
     end
 
+    def resolve_output(path)
+      output = File.basename(path, '.*') + '.' + @format.to_s
+
+      unless @output.nil?
+        abs_path = File.absolute_path(@output)
+
+        if File.directory? @output  # COMBAK: or abs_path?
+          output = abs_path + File::SEPARATOR + output
+        else
+          output = abs_path
+        end
+      end
+
+      fail "output file exists: #{output}" if File.exist? output
+      output
+    end
+
     def process_input(path)
       seconds = Time.now.tv_sec
 
       unless @scan or @detect
-        output_path = File.basename(path, '.*') + '.' + @format.to_s
+        output_path = resolve_output(path)
         fail_or_warn "output file already exists: #{output_path}" if File.exist? output_path
 
         log_path = output_path + '.log'


### PR DESCRIPTION
Code entirely borrowed from `transcode-video` ([`resolve_output`](https://github.com/donmelton/video_transcoding/blob/5c3d5e3cdcbada016353cbc874c54f1213fd3794/bin/transcode-video#L889-L904), [`opts.on '--output ARG'`](https://github.com/donmelton/video_transcoding/blob/5c3d5e3cdcbada016353cbc874c54f1213fd3794/bin/transcode-video#L303-L318), [help text](https://github.com/donmelton/video_transcoding/blob/5c3d5e3cdcbada016353cbc874c54f1213fd3794/bin/transcode-video#L46-L49)). For consistency's sake, I skipped the short option (`-o`). Also, I appreciated that the change to use `resolve_output` was a one-liner.

There are two minor COMBAK notes for your feedback (lines 480 and 1190 in 241b41e).

<details>

<summary>Dockerfile</summary>

I'm on NixOS and way too lazy to set up the dependencies at the OS level. I might send this file as a separate PR, although I don't have a Docker Hub account with which to get the image to the masses.
```
FROM ruby:3-slim

RUN apt-get update \
    && apt-get install -y ffmpeg mkvtoolnix mpv \
    && useradd -Nmu 1000 app

USER 1000
COPY --chown=1000 . /app
WORKDIR /home/app

ENTRYPOINT ["/app/bin/other-transcode"]
```
</details>

<details>
<summary>Test script</summary>

```
#!/usr/bin/env bash

set -x

mkdir outdir

transcode() {
  sudo docker run --rm -it -v "$PWD:$PWD" -w "$PWD" other-transcode "$@"
}

transcode whosonfirst.mkv &> output_to_pwd
transcode whosonfirst.mkv --output outdir &> output_to_dir
transcode whosonfirst.mkv --output outfile.mkv &> output_to_outfile

exa -lR
```
</details>

<details>
<summary>Results</summary>

```
ag@server /dev/shm ❯ exa -l
.rwxr-xr-x 311 ag 19 Mar 17:11 test
.rw-r--r-- 39M ag 19 Mar 17:12 whosonfirst.mkv
ag@server /dev/shm ❯ ./test
+ mkdir outdir
+ transcode whosonfirst.mkv
+ transcode whosonfirst.mkv --output outdir
+ transcode whosonfirst.mkv --output outfile.mkv
+ exa -lR
drwxr-xr-x    - ag 19 Mar 17:14 outdir
.rw-r--r--  98M ag 19 Mar 17:15 outfile.mkv
.rw-r--r-- 6.9k ag 19 Mar 17:15 outfile.mkv.log
.rw-r--r--  14k ag 19 Mar 17:14 output_to_dir
.rw-r--r--  14k ag 19 Mar 17:15 output_to_outfile
.rw-r--r--  364 ag 19 Mar 17:13 output_to_pwd
.rwxr-xr-x  311 ag 19 Mar 17:12 test
.rw-r--r--  39M ag 19 Mar 17:12 whosonfirst.mkv

./outdir:
.rw-r--r--  98M ag 19 Mar 17:14 whosonfirst.mkv
.rw-r--r-- 6.9k ag 19 Mar 17:14 whosonfirst.mkv.log
```
(The size difference? I suspect the VP9 original has a much lower bitrate than the 1.5 MB/s the AVC output was written in, but `mediainfo` won't tell me what it is. I needed a very small video to test with anyway.)
</details>

<details>
<summary>Relevant log lines</summary>

You can see at the end of the ffmpeg commands that the output path resolved correctly.
```
ag@server /dev/shm ❯ tail -1 output_to_pwd
/app/bin/other-transcode: output file exists: whosonfirst.mkv
ag@server /dev/shm ❯ grep ^ffmpeg output_to_dir
ffmpeg -loglevel error -stats -i whosonfirst.mkv -map 0:0 -c:v libx264 -b:v 1500k -maxrate:v 10000k -bufsize:v 10000k -mbtree:v 0 -profile:v high -color_primaries:v bt709 -color_trc:v bt709 -colorspace:v bt709 -metadata:s:v title\= -disposition:v default -map 0:1 -c:a:0 aac -metadata:s:a:0 title\= -disposition:a:0 default -sn -metadata:g title\= -default_mode passthrough /dev/shm/outdir/whosonfirst.mkv
ag@server /dev/shm ❯ grep ^ffmpeg output_to_outfile
ffmpeg -loglevel error -stats -i whosonfirst.mkv -map 0:0 -c:v libx264 -b:v 1500k -maxrate:v 10000k -bufsize:v 10000k -mbtree:v 0 -profile:v high -color_primaries:v bt709 -color_trc:v bt709 -colorspace:v bt709 -metadata:s:v title\= -disposition:v default -map 0:1 -c:a:0 aac -metadata:s:a:0 title\= -disposition:a:0 default -sn -metadata:g title\= -default_mode passthrough /dev/shm/outfile.mkv
```
</details>